### PR TITLE
TT_add_IncludeBody_to_Lambda_Function_Associations_in_cloudfront

### DIFF
--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -526,6 +526,7 @@ func lambdaFunctionAssociationHash(v interface{}) int {
 	m := v.(map[string]interface{})
 	buf.WriteString(fmt.Sprintf("%s-", m["event_type"].(string)))
 	buf.WriteString(fmt.Sprintf("%s", m["lambda_arn"].(string)))
+	buf.WriteString(fmt.Sprintf("%t", m["include_body"].(bool)))
 	return hashcode.String(buf.String())
 }
 
@@ -554,6 +555,9 @@ func expandLambdaFunctionAssociation(lf map[string]interface{}) *cloudfront.Lamb
 	if v, ok := lf["lambda_arn"]; ok {
 		lfa.LambdaFunctionARN = aws.String(v.(string))
 	}
+	if v, ok := lf["include_body"]; ok {
+		lfa.IncludeBody = aws.Bool(v.(bool))
+	}
 	return &lfa
 }
 
@@ -570,6 +574,7 @@ func flattenLambdaFunctionAssociation(lfa *cloudfront.LambdaFunctionAssociation)
 	if lfa != nil {
 		m["event_type"] = *lfa.EventType
 		m["lambda_arn"] = *lfa.LambdaFunctionARN
+		m["include_body"] = *lfa.IncludeBody
 	}
 	return m
 }

--- a/aws/cloudfront_distribution_configuration_structure_test.go
+++ b/aws/cloudfront_distribution_configuration_structure_test.go
@@ -50,15 +50,16 @@ func trustedSignersConf() []interface{} {
 func lambdaFunctionAssociationsConf() *schema.Set {
 	x := []interface{}{
 		map[string]interface{}{
-			"event_type": "viewer-request",
-			"lambda_arn": "arn:aws:lambda:us-east-1:999999999:function1:alias",
+			"event_type":   "viewer-request",
+			"lambda_arn":   "arn:aws:lambda:us-east-1:999999999:function1:alias",
+			"include_body": true,
 		},
 		map[string]interface{}{
-			"event_type": "origin-response",
-			"lambda_arn": "arn:aws:lambda:us-east-1:999999999:function2:alias",
+			"event_type":   "origin-response",
+			"lambda_arn":   "arn:aws:lambda:us-east-1:999999999:function2:alias",
+			"include_body": true,
 		},
 	}
-
 	return schema.NewSet(lambdaFunctionAssociationHash, x)
 }
 

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -124,6 +124,11 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 										Type:     schema.TypeString,
 										Required: true,
 									},
+									"include_body": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
 								},
 							},
 							Set: lambdaFunctionAssociationHash,
@@ -248,6 +253,11 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 									"lambda_arn": {
 										Type:     schema.TypeString,
 										Required: true,
+									},
+									"include_body": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
 									},
 								},
 							},
@@ -403,6 +413,11 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 									"lambda_arn": {
 										Type:     schema.TypeString,
 										Required: true,
+									},
+									"include_body": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
 									},
 								},
 							},

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -306,7 +306,7 @@ resource "aws_cloudfront_distribution" "example" {
   Valid values: `viewer-request`, `origin-request`, `viewer-response`,
   `origin-response`
 * `lambda_arn` (Required) - ARN of the Lambda function.
-* `include_body` (Optional) - When specified it includes the body of the request whithin the lambda function. Defaults to false. Valid values: `true`, `false`.
+* `include_body` (Optional) - When set to true it exposes the request body to the lambda function. Defaults to false. Valid values: `true`, `false`.
 
 ##### Cookies Arguments
 

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -306,8 +306,7 @@ resource "aws_cloudfront_distribution" "example" {
   Valid values: `viewer-request`, `origin-request`, `viewer-response`,
   `origin-response`
 * `lambda_arn` (Required) - ARN of the Lambda function.
-* `include_body` (Optional) - When specified it includes the body of the request whithin the lambda function. Defaults to false.
-  Valid Values: `true`, `false`.
+* `include_body` (Optional) - When specified it includes the body of the request whithin the lambda function. Defaults to false. Valid values: `true`, `false`.
 
 ##### Cookies Arguments
 

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -294,8 +294,9 @@ resource "aws_cloudfront_distribution" "example" {
     # ... other configuration ...
 
     lambda_function_association {
-      event_type = "viewer-request"
-      lambda_arn = "${aws_lambda_function.example.qualified_arn}"
+      event_type   = "viewer-request"
+      lambda_arn   = "${aws_lambda_function.example.qualified_arn}"
+      include_body = false
     }
   }
 }
@@ -305,6 +306,8 @@ resource "aws_cloudfront_distribution" "example" {
   Valid values: `viewer-request`, `origin-request`, `viewer-response`,
   `origin-response`
 * `lambda_arn` (Required) - ARN of the Lambda function.
+* `include_body` (Optional) - When specified it includes the body of the request whithin the lambda function. Defaults to false.
+  Valid Values: `true`, `false`.
 
 ##### Cookies Arguments
 


### PR DESCRIPTION
Currently the terraform-provider-aws doesn't support the include_body option in the lambda_function_association for cloudfront. This is what's in the documentation:
```json
"Items": [
                  {
                    "LambdaFunctionARN": "string",
                    "EventType": "viewer-request"|"viewer-response"|"origin-request"|"origin-response",
                    "IncludeBody": true|false
                  }
                  ...
                ]
```
**Changes proposed in this pull request:**

Adding a missing option to the `lambda_function_association` in cloudfront that we need and is not supported by terraform-provider-aws.

* add the `include_body` parameter in the `lambda_function_association`
![image](https://user-images.githubusercontent.com/2648043/44587682-f9660f00-a7b3-11e8-939d-05131f3a12b5.png)

**Output from acceptance testing:**

please note that I had to manually adjust the timeout to 1000m because the tests where timing out due to cloudfront being slow
```sh
make testacc TESTARGS='-run=TestAccAWSCloudFrontDistribution'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSCloudFrontDistribution -timeout 1000m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSCloudFrontDistribution_importBasic
--- PASS: TestAccAWSCloudFrontDistribution_importBasic (828.70s)
=== RUN   TestAccAWSCloudFrontDistribution_S3Origin
--- PASS: TestAccAWSCloudFrontDistribution_S3Origin (805.78s)
=== RUN   TestAccAWSCloudFrontDistribution_S3OriginWithTags
--- PASS: TestAccAWSCloudFrontDistribution_S3OriginWithTags (1028.92s)
=== RUN   TestAccAWSCloudFrontDistribution_customOrigin
--- PASS: TestAccAWSCloudFrontDistribution_customOrigin (830.72s)
=== RUN   TestAccAWSCloudFrontDistribution_multiOrigin
--- PASS: TestAccAWSCloudFrontDistribution_multiOrigin (1021.48s)
=== RUN   TestAccAWSCloudFrontDistribution_orderedCacheBehavior
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehavior (964.56s)
=== RUN   TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName (2.29s)
=== RUN   TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID (2.09s)
=== RUN   TestAccAWSCloudFrontDistribution_noOptionalItemsConfig
--- PASS: TestAccAWSCloudFrontDistribution_noOptionalItemsConfig (832.29s)
=== RUN   TestAccAWSCloudFrontDistribution_HTTP11Config
--- PASS: TestAccAWSCloudFrontDistribution_HTTP11Config (748.69s)
=== RUN   TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig
--- PASS: TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig (804.62s)
=== RUN   TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig
--- PASS: TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig (919.45s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	8789.627s
...
```
