### PR TITLE
Sort acm cert domain opts correctly

### DIFF
--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -324,18 +324,16 @@ func convertValidationOptions(certificate *acm.CertificateDetail) ([]map[string]
 // order different each time.
 func sortDomainValidationOptions(domainName *string, domainValiationOptions []map[string]interface{}) {
 	sort.Slice(domainValiationOptions, func(i, j int) bool {
+		if domainValiationOptions[i]["domain_name"].(string) == *domainName {
+			return true
+		}
+		if domainValiationOptions[j]["domain_name"].(string) == *domainName {
+			return false
+		}
+
 		return domainValiationOptions[i]["domain_name"].(string) <
 			domainValiationOptions[j]["domain_name"].(string)
 	})
-
-	for i, option := range domainValiationOptions {
-		if option["domain_name"] == domainName {
-			swap := domainValiationOptions[0]
-			domainValiationOptions[0] = domainValiationOptions[i]
-			domainValiationOptions[i] = swap
-			break
-		}
-	}
 }
 
 func resourceAwsAcmCertificateDelete(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
As pointed out by @jansiwy there the sorting was not correct in the original implementation. For one thing it generated a reverse sorting in the list's tail. Moreover, the swapping after sorting lead to the sorting being broken in the tail.

The current implementation should fix the bug(s). It was tested with the following test code:

```go
func TestSortDomainValidationOptions(t *testing.T) {

	domainName := "www.example.com"

	data := []map[string][]string{
		map[string][]string{
			"input":  []string{},
			"sorted": []string{},
		},
		map[string][]string{
			"input":  []string{"www.example.com"},
			"sorted": []string{"www.example.com"},
		},
		map[string][]string{
			"input":  []string{"www.example.com", "a.example.com", "b.example.com"},
			"sorted": []string{"www.example.com", "a.example.com", "b.example.com"},
		},
		map[string][]string{
			"input":  []string{"a.example.com", "b.example.com", "www.example.com", "c.example.com"},
			"sorted": []string{"www.example.com", "a.example.com", "b.example.com", "c.example.com"},
		},
		map[string][]string{
			"input":  []string{"a.example.com", "b.example.com", "c.example.com", "www.example.com"},
			"sorted": []string{"www.example.com", "a.example.com", "b.example.com", "c.example.com"},
		},
		map[string][]string{
			"input":  []string{"a.example.com", "z.example.com", "b.example.com", "www.example.com"},
			"sorted": []string{"www.example.com", "a.example.com", "b.example.com", "z.example.com"},
		},
		map[string][]string{
			"input":  []string{"www.example.com", "a.example.com", "b.example.com", "z.example.com"},
			"sorted": []string{"www.example.com", "a.example.com", "b.example.com", "z.example.com"},
		},
		map[string][]string{
			"input":  []string{"www.example.com", "z.example.com", "b.example.com", "a.example.com"},
			"sorted": []string{"www.example.com", "a.example.com", "b.example.com", "z.example.com"},
		},
		map[string][]string{
			"input":  []string{"www.example.com", "z.example.com", "b.example.com", "a.example.com"},
			"sorted": []string{"www.example.com", "a.example.com", "b.example.com", "z.example.com"},
		},
	}

	for _, testCase := range data {
		var options []map[string]interface{}

		for _, domainName := range testCase["input"] {
			options = append(options,
				map[string]interface{}{
					"domain_name": domainName,
				},
			)
		}

		fmt.Printf("in: %v\n", options)
		sortDomainValidationOptions(&domainName, options)
		fmt.Printf("out: %v\n\n", options)

		for i := range options {
			actual := options[i]["domain_name"].(string)
			expected := testCase["sorted"][i]

			if actual != expected {
				t.Errorf("\ninput was: %v\ngot: %v\nwant: %v\n", testCase["input"], options, testCase["sorted"])
				break
			}
		}

	}
}
```

Which produces
```
in: []
out: []

in: [map[domain_name:www.example.com]]
out: [map[domain_name:www.example.com]]

in: [map[domain_name:www.example.com] map[domain_name:a.example.com] map[domain_name:b.example.com]]
out: [map[domain_name:www.example.com] map[domain_name:a.example.com] map[domain_name:b.example.com]]

in: [map[domain_name:a.example.com] map[domain_name:b.example.com] map[domain_name:www.example.com] map[domain_name:c.example.com]]
out: [map[domain_name:www.example.com] map[domain_name:a.example.com] map[domain_name:b.example.com] map[domain_name:c.example.com]]

in: [map[domain_name:a.example.com] map[domain_name:b.example.com] map[domain_name:c.example.com] map[domain_name:www.example.com]]
out: [map[domain_name:www.example.com] map[domain_name:a.example.com] map[domain_name:b.example.com] map[domain_name:c.example.com]]

in: [map[domain_name:a.example.com] map[domain_name:z.example.com] map[domain_name:b.example.com] map[domain_name:www.example.com]]
out: [map[domain_name:www.example.com] map[domain_name:a.example.com] map[domain_name:b.example.com] map[domain_name:z.example.com]]

in: [map[domain_name:www.example.com] map[domain_name:a.example.com] map[domain_name:b.example.com] map[domain_name:z.example.com]]
out: [map[domain_name:www.example.com] map[domain_name:a.example.com] map[domain_name:b.example.com] map[domain_name:z.example.com]]

in: [map[domain_name:www.example.com] map[domain_name:z.example.com] map[domain_name:b.example.com] map[domain_name:a.example.com]]
out: [map[domain_name:www.example.com] map[domain_name:a.example.com] map[domain_name:b.example.com] map[domain_name:z.example.com]]

in: [map[domain_name:www.example.com] map[domain_name:z.example.com] map[domain_name:b.example.com] map[domain_name:a.example.com]]
out: [map[domain_name:www.example.com] map[domain_name:a.example.com] map[domain_name:b.example.com] map[domain_name:z.example.com]]

PASS
ok  	go/sort-cert-options	0.006s
```

