### PR TITLE
Release only after unit tests passed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,4 +57,4 @@ deploy:
   on:
     branch: master
     tags: true
-  condition: ${GIT_TAG} =~ ^v[0-9]+\.[0-9]+\.[0-9]$
+  condition: ${GIT_TAG} =~ ^v[0-9]+\.[0-9]+\.[0-9]$ AND ${JOB_NAME} = "Code UnitTest"


### PR DESCRIPTION
Currently it would upload binaries 3 times. Therefore limiting it to only one build.