### PR TITLE
Allow default event bus to be specified

### DIFF
--- a/aws/resource_aws_cloudwatch_event_rule.go
+++ b/aws/resource_aws_cloudwatch_event_rule.go
@@ -48,7 +48,7 @@ func resourceAwsCloudWatchEventRule() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validateCloudWatchEventBusName,
+				ValidateFunc: validateCloudWatchEventEventBusNameReference,
 			},
 			"event_pattern": {
 				Type:         schema.TypeString,

--- a/aws/resource_aws_cloudwatch_event_target.go
+++ b/aws/resource_aws_cloudwatch_event_target.go
@@ -32,7 +32,7 @@ func resourceAwsCloudWatchEventTarget() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validateCloudWatchEventBusName,
+				ValidateFunc: validateCloudWatchEventEventBusNameReference,
 			},
 
 			"rule": {

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -2373,6 +2373,40 @@ func validateRoute53ResolverName(v interface{}, k string) (ws []string, errors [
 }
 
 func validateCloudWatchEventBusName(v interface{}, k string) (ws []string, errors []error) {
+	// The names of custom event buses can't contain the / character. You can't
+	// use the name default for a custom event bus because this name is already
+	// used for your account's default event bus.
+	//
+	// If this is a partner event bus, the name must exactly match the name of the
+	// partner event source that this event bus is matched to. This name will include
+	// the / character.
+	value := v.(string)
+
+	if strings.HasPrefix(value, "aws.") {
+		// should be a partner event bus
+		return validateCloudWatchEventSourceName(v, k)
+	}
+
+	if len(value) < 1 {
+		errors = append(errors, fmt.Errorf("%q cannot be less than 1 character: %q", k, value))
+	} else if len(value) > 256 {
+		errors = append(errors, fmt.Errorf("%q cannot be longer than 256 characters: %q", k, value))
+	} else if value == "default" {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be default because this name is already used for your account's default event bus", k))
+	}
+
+	pattern := `^[a-zA-Z0-9._\-]+$`
+	if !regexp.MustCompile(pattern).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q doesn't comply with restrictions (%q): %q",
+			k, pattern, value))
+	}
+
+	return
+}
+
+func validateCloudWatchEventEventBusNameReference(v interface{}, k string) (ws []string, errors []error) {
 	// The names of custom event buses can't contain the / character.
 	//
 	// If this is a partner event bus, the name must exactly match the name of the

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -2373,9 +2373,7 @@ func validateRoute53ResolverName(v interface{}, k string) (ws []string, errors [
 }
 
 func validateCloudWatchEventBusName(v interface{}, k string) (ws []string, errors []error) {
-	// The names of custom event buses can't contain the / character. You can't
-	// use the name default for a custom event bus because this name is already
-	// used for your account's default event bus.
+	// The names of custom event buses can't contain the / character.
 	//
 	// If this is a partner event bus, the name must exactly match the name of the
 	// partner event source that this event bus is matched to. This name will include
@@ -2391,9 +2389,6 @@ func validateCloudWatchEventBusName(v interface{}, k string) (ws []string, error
 		errors = append(errors, fmt.Errorf("%q cannot be less than 1 character: %q", k, value))
 	} else if len(value) > 256 {
 		errors = append(errors, fmt.Errorf("%q cannot be longer than 256 characters: %q", k, value))
-	} else if value == "default" {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be default because this name is already used for your account's default event bus", k))
 	}
 
 	pattern := `^[a-zA-Z0-9._\-]+$`


### PR DESCRIPTION
The validation does not work as for e.g `aws_cloudwatch_event_target` the event bus needs to be configured as the "read" will always set this in the state file 