### PR TITLE
Fix tfproviderlint checks

### DIFF
--- a/aws/resource_aws_cloudwatch_event_bus.go
+++ b/aws/resource_aws_cloudwatch_event_bus.go
@@ -41,10 +41,6 @@ func resourceAwsCloudWatchEventBus() *schema.Resource {
 			"policy": {
 				Type:     schema.TypeString,
 				Computed: true,
-				StateFunc: func(v interface{}) string {
-					json, _ := structure.NormalizeJsonString(v.(string))
-					return json
-				},
 			},
 		},
 	}
@@ -98,7 +94,12 @@ func resourceAwsCloudWatchEventBusRead(d *schema.ResourceData, meta interface{})
 
 	d.Set("arn", output.Arn)
 	d.Set("name", output.Name)
-	d.Set("policy", output.Policy)
+
+	json, err := structure.NormalizeJsonString(*output.Policy)
+	if err != nil {
+		return fmt.Errorf("policy contains an invalid JSON: %s", err)
+	}
+	d.Set("policy", json)
 
 	return nil
 }

--- a/aws/resource_aws_opsworks_permission.go
+++ b/aws/resource_aws_opsworks_permission.go
@@ -69,17 +69,10 @@ func resourceAwsOpsworksPermissionDelete(d *schema.ResourceData, meta interface{
 		req.Level = aws.String("iam_only")
 	}
 
-	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
-		var cerr error
-		_, cerr = client.SetPermission(req)
-		if cerr != nil {
-			log.Printf("[INFO] client error")
-			return resource.NonRetryableError(cerr)
-		}
-		return nil
-	})
+	_, err := client.SetPermission(req)
 
 	if err != nil {
+		log.Printf("[INFO] client error")
 		return err
 	}
 
@@ -188,17 +181,10 @@ func resourceAwsOpsworksPermissionUpdate(d *schema.ResourceData, meta interface{
 		req.Level = aws.String(lns)
 	}
 
-	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
-		var cerr error
-		_, cerr = client.SetPermission(req)
-		if cerr != nil {
-			log.Printf("[INFO] client error")
-			return resource.NonRetryableError(cerr)
-		}
-		return nil
-	})
+	_, err := client.SetPermission(req)
 
 	if err != nil {
+		log.Printf("[INFO] client error")
 		return err
 	}
 


### PR DESCRIPTION
The `tfproviderlint` is not enabled to check (https://github.com/terraform-providers/terraform-provider-aws/issues/11864) on this odd behavior of using `retry` for responses which never return a `RetryableError`. https://github.com/bflad/tfproviderlint/blob/master/passes/R006/README.md
Therefore dropping the `retry` completely here.

The send part is about `S033` of `tfproviderlint` which requires the `StateFunc` to not be present for computed attributes.